### PR TITLE
removedOnCompletion,fillModeを追加

### DIFF
--- a/CircularRevealAnimator/CircularRevealAnimator/CircularRevealAnimator.swift
+++ b/CircularRevealAnimator/CircularRevealAnimator/CircularRevealAnimator.swift
@@ -54,15 +54,10 @@ extension CircularRevealAnimator : UIViewControllerAnimatedTransitioning {
         
         if spreading {
             containerView.insertSubview(target, aboveSubview: source)
+            
             let animation = CABasicAnimation(keyPath: "path", fromValue: startPath, toValue: endPath, duration: duration, timingFunction: timingFunction, delegate: delegate)
             
-            target.layer.mask = { () -> CALayer in
-                let mask = CAShapeLayer()
-                mask.path = endPath
-                
-                return mask
-            }()
-            
+            target.layer.mask = CAShapeLayer()
             target.layer.mask.addAnimation(animation, forKey: "circular")
         } else {
             containerView.insertSubview(target, belowSubview: source)
@@ -94,5 +89,8 @@ extension CABasicAnimation {
         self.duration = duration
         self.timingFunction = timingFunction
         self.delegate = delegate
+        
+        self.removedOnCompletion = false
+        self.fillMode = kCAFillModeForwards
     }
 }


### PR DESCRIPTION
CircularRevealAnimatorはとても興味深いライブラリだと思いました! 僭越ながら少々コメントさせてください。

```
self.removedOnCompletion = false
self.fillMode = kCAFillModeForwards
```

上のコードを追加すれば、アニメーション終了時の状態を維持することができます。

target.layer.maskの初期値はnilなので、下のように初期値を設定してから、addAnimationすればendPathを予め設定する必要はなくなると思いました。

```
target.layer.mask = CAShapeLayer()
```
